### PR TITLE
added threat_intelligence plugin ownership to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -586,6 +586,9 @@ x-pack/plugins/session_view @elastic/awp-platform
 x-pack/plugins/security_solution/public/common/components/sessions_viewer @elastic/awp-platform
 x-pack/plugins/security_solution/public/kubernetes @elastic/awp-platform
 
+## Security Solution sub teams - Protections Experience
+x-pack/plugins/threat_intelligence @elastic/protections-experience
+
 # Security Intelligence And Analytics
 /x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules @elastic/security-intelligence-analytics
 


### PR DESCRIPTION
As far as I understand this is  required if we want to be added as reviewers in case someone changes this code path