### PR TITLE
[TIP] Update default page layout with header to match mocks

### DIFF
--- a/x-pack/plugins/threat_intelligence/public/components/layout/layout.stories.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/layout/layout.stories.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { Story } from '@storybook/react';
+import { EuiText } from '@elastic/eui';
+import { DefaultPageLayout } from './layout';
+
+export default {
+  component: DefaultPageLayout,
+  title: 'DefaultPageLayout',
+};
+
+export const Default: Story<void> = () => {
+  const title = 'Title with border below';
+  const children = <EuiText>Content with border above</EuiText>;
+
+  return <DefaultPageLayout pageTitle={title} children={children} />;
+};
+
+export const NoBorder: Story<void> = () => {
+  const title = 'Title without border';
+  const border = false;
+  const children = <EuiText>Content without border</EuiText>;
+
+  return <DefaultPageLayout pageTitle={title} border={border} children={children} />;
+};

--- a/x-pack/plugins/threat_intelligence/public/components/layout/layout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/components/layout/layout.tsx
@@ -5,27 +5,32 @@
  * 2.0.
  */
 
-import { EuiPageBody, EuiPageContent, EuiText } from '@elastic/eui';
+import { EuiPageHeader, EuiPageHeaderSection, EuiSpacer, EuiText } from '@elastic/eui';
 import React, { FC } from 'react';
 
-interface LayoutProps {
+export interface LayoutProps {
   pageTitle?: string;
+  border?: boolean;
 }
 
 export const displayName = 'DefaultPageLayout';
 
-export const DefaultPageLayout: FC<LayoutProps> = ({ children, pageTitle }) => (
-  <EuiPageBody>
-    <EuiPageContent>
-      {pageTitle && (
-        <EuiText>
-          <h2 data-testid={`${displayName}-subheader`}>{pageTitle}</h2>
-        </EuiText>
-      )}
-
+export const DefaultPageLayout: FC<LayoutProps> = ({ children, pageTitle, border = true }) => {
+  return (
+    <>
+      <EuiPageHeader alignItems="center" bottomBorder={border}>
+        <EuiPageHeaderSection>
+          {pageTitle && (
+            <EuiText>
+              <h2 data-testid={`${displayName}-subheader`}>{pageTitle}</h2>
+            </EuiText>
+          )}
+        </EuiPageHeaderSection>
+      </EuiPageHeader>
+      <EuiSpacer size="l" />
       {children}
-    </EuiPageContent>
-  </EuiPageBody>
-);
+    </>
+  );
+};
 
 DefaultPageLayout.displayName = displayName;

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_flyout/indicators_flyout.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/components/indicators_flyout/indicators_flyout.tsx
@@ -15,6 +15,7 @@ import {
   EuiTabs,
   EuiText,
   EuiTitle,
+  useGeneratedHtmlId,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { fullDateFormatter } from '../../../../common/utils/dates';
@@ -84,12 +85,15 @@ export const IndicatorsFlyout: VFC<{ indicator: Indicator; closeFlyout: () => vo
   const firstSeen = unwrapValue(indicator, RawIndicatorFieldId.FirstSeen);
   const value = displayValue(indicator) || EMPTY_VALUE;
   const formattedFirstSeen: string = firstSeen ? fullDateFormatter(firstSeen) : EMPTY_VALUE;
+  const flyoutTitleId = useGeneratedHtmlId({
+    prefix: 'simpleFlyoutTitle',
+  });
 
   return (
-    <EuiFlyout onClose={closeFlyout}>
+    <EuiFlyout onClose={closeFlyout} aria-labelledby={flyoutTitleId}>
       <EuiFlyoutHeader hasBorder>
         <EuiTitle>
-          <h2 data-test-subj={TITLE_TEST_ID}>
+          <h2 data-test-subj={TITLE_TEST_ID} id={flyoutTitleId}>
             <FormattedMessage
               id="xpack.threatIntelligence.indicator.flyout.panelTitle"
               defaultMessage="Indicator: {title}"

--- a/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.tsx
+++ b/x-pack/plugins/threat_intelligence/public/modules/indicators/indicators_page.tsx
@@ -11,6 +11,7 @@ import { useIndicators } from './hooks/use_indicators';
 import { EmptyPage } from '../../components/empty_page';
 import { useIndicatorsTotalCount } from './hooks/use_indicators_total_count';
 import { useIntegrationsPageLink } from '../../hooks/use_integrations_page_link';
+import { DefaultPageLayout } from '../../components/layout';
 
 export const IndicatorsPage: VFC = () => {
   const indicators = useIndicators();
@@ -22,6 +23,8 @@ export const IndicatorsPage: VFC = () => {
   return showEmptyPage ? (
     <EmptyPage integrationsPageLink={integrationsPageLink} />
   ) : (
-    <IndicatorsTable {...indicators} />
+    <DefaultPageLayout pageTitle={'Indicators'}>
+      <IndicatorsTable {...indicators} />
+    </DefaultPageLayout>
   );
 };


### PR DESCRIPTION
## Summary

Modified the default page layout to have a header closer to the mocks. Following at the same time the patterns the Security Solution plugin is using with their [HeaderPageComponent](https://github.com/lgmys/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/header_page/index.tsx).

The default page layout is only applied to the Indicator page, not the Empty page.

In the app:

https://user-images.githubusercontent.com/17276605/178590289-38aab235-bd68-4d9b-a0ab-2c9da52ff9ce.mov

And added a story to Storybook 

https://user-images.githubusercontent.com/17276605/178590332-a50134d6-2764-4c05-97ed-ab399edf3757.mov

### How to test:

```
unit test:
npm run test:jest --config ./x-pack/plugins/threat_intelligence

storybook:
node scripts/storybook threat_intelligence
```